### PR TITLE
fix: stabilize toast hook and class merging

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,5 +2,7 @@ import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  // Spread the inputs so clsx receives a flat argument list
+  // otherwise nested arrays may not be merged as expected
+  return twMerge(clsx(...inputs))
 }


### PR DESCRIPTION
## Summary
- ensure toast hook subscribes to listener only once
- spread inputs in `cn` to fix class merging

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype; A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68991f755b7c832dbe97f1d10575326f